### PR TITLE
fix parsing of vessel id radio callsign and aircraft reg marking

### DIFF
--- a/src/main/java/au/gov/amsa/sgb/decoder/Detection.java
+++ b/src/main/java/au/gov/amsa/sgb/decoder/Detection.java
@@ -492,15 +492,15 @@ public final class Detection {
 
     @VisibleForTesting
     static RadioCallSign readVesselIdRadioCallSign(Bits bits) {
-        bits.skip(2);
         String s = bits.readBaudotCharacters(7).trim();
+        bits.skip(2);
         return new RadioCallSign(s);
     }
 
     @VisibleForTesting
     static AircraftRegistrationMarking readVesselIdAicraftRegistrationMarking(Bits bits) {
-        bits.skip(2);
         String s = bits.readBaudotCharacters(7).trim();
+        bits.skip(2);
         return new AircraftRegistrationMarking(s);
     }
 

--- a/src/test/java/au/gov/amsa/sgb/decoder/Beacon23HexIdTest.java
+++ b/src/test/java/au/gov/amsa/sgb/decoder/Beacon23HexIdTest.java
@@ -12,6 +12,8 @@ import org.junit.Test;
 import com.google.common.io.Files;
 
 import au.gov.amsa.sgb.decoder.internal.json.Json;
+import au.gov.amsa.sgb.decoder.vesselid.AircraftRegistrationMarking;
+import au.gov.amsa.sgb.decoder.vesselid.RadioCallSign;
 
 public class Beacon23HexIdTest {
 
@@ -34,11 +36,26 @@ public class Beacon23HexIdTest {
     public void testDecodeHexWrongSize() {
         Beacon23HexId.fromHex("123");
     }
-    
-    @Test(expected = IllegalArgumentException.class)
-    public void testBadBaudotCode() {
-        // contains a baudot code of 14 which is not permitted
-        Beacon23HexId.fromHex("ADF7DA6D7092E33BA475940");
+
+    @Test
+    public void testRadioCallSignDecode7Characters() {
+        Beacon23HexId b = Beacon23HexId.fromHex("ADF7DA6D7092E33BA475940");
+        RadioCallSign r = (RadioCallSign) b.vesselId().get();
+        assertEquals("ABC 123", r.value().get());
+    }
+
+    @Test
+    public void testRadioCallSignDecode6Characters() {
+        RadioCallSign r = (RadioCallSign) // 
+            Beacon23HexId.fromHex("A037DA6D7092937D7175940").vesselId().get();
+        assertEquals("XYZ123", r.value().get());
+    }
+
+    @Test
+    public void testRegistrationMarking() {
+        AircraftRegistrationMarking r = (AircraftRegistrationMarking) //
+            Beacon23HexId.fromHex("B5F46E783F23924E9D65028").vesselId().get();
+        assertEquals("J1234", r.value().get());
     }
 
 }

--- a/src/test/java/au/gov/amsa/sgb/decoder/ComplianceKitTest.java
+++ b/src/test/java/au/gov/amsa/sgb/decoder/ComplianceKitTest.java
@@ -115,6 +115,7 @@ public class ComplianceKitTest {
                 .map(line -> line.trim()) //
                 .filter(line -> !line.isEmpty()) //
                 .forEach(line -> {
+                    System.out.println(line);
                     String[] items = line.split(",");
                     assertEquals(4, items.length);
                     String type = removeQuotes(items[0]);

--- a/src/test/java/au/gov/amsa/sgb/decoder/ComplianceKitTest.java
+++ b/src/test/java/au/gov/amsa/sgb/decoder/ComplianceKitTest.java
@@ -115,7 +115,6 @@ public class ComplianceKitTest {
                 .map(line -> line.trim()) //
                 .filter(line -> !line.isEmpty()) //
                 .forEach(line -> {
-                    System.out.println(line);
                     String[] items = line.split(",");
                     assertEquals(4, items.length);
                     String type = removeQuotes(items[0]);

--- a/src/test/java/au/gov/amsa/sgb/decoder/DetectionTest.java
+++ b/src/test/java/au/gov/amsa/sgb/decoder/DetectionTest.java
@@ -149,20 +149,18 @@ public class DetectionTest {
 
     @Test
     public void testReadVesselIdAicraftRegistrationMarking() {
-        // two zeros then a space then VH-ABC using Baudot
         Bits b = createVesselIdAircraftRegistrationMarkingVhAbc();
         AircraftRegistrationMarking a = Detection.readVesselIdAicraftRegistrationMarking(b);
         assertEquals("VH-ABC", a.value().get());
     }
 
     static Bits createVesselIdAircraftRegistrationMarkingVhAbc() {
-        return Bits.from("00100100101111100101011000111000110011101110");
+        return Bits.from("10010010111110010101100011100011001110111000");
     }
 
     @Test
     public void testReadVesselIdAicraftRegistrationMarkingNotPresent() {
-        // two zeros then spaces using Baudot
-        Bits b = Bits.from("00100100100100100100100100100100100100100100");
+        Bits b = Bits.from("10010010010010010010010010010010010010010000");
         AircraftRegistrationMarking a = Detection.readVesselIdAicraftRegistrationMarking(b);
         assertFalse(a.value().isPresent());
     }
@@ -176,18 +174,18 @@ public class DetectionTest {
 
     @Test
     public void testReadVesselIdRadioCallSign() {
-        Bits b = createVesselIdRadioCallSignForBingo();
+        Bits b = createVesselIdRadioCallSignForAbcSpace123();
         RadioCallSign a = Detection.readVesselIdRadioCallSign(b);
-        assertEquals("BINGO", a.value().get());
+        assertEquals("ABC 123", a.value().get());
     }
 
-    private static Bits createVesselIdRadioCallSignForBingo() {
-        return Bits.from("00110011101100100110101011100011100100100100");
+    private static Bits createVesselIdRadioCallSignForAbcSpace123() {
+        return Bits.from("11100011001110111010010001110101100101000000");
     }
 
     @Test
     public void testReadVesselIdRadioCallSignNotPresent() {
-        Bits b = Bits.from("00100100100100100100100100100100100100100100");
+        Bits b = Bits.from("10010010010010010010010010010010010010010000");
         RadioCallSign a = Detection.readVesselIdRadioCallSign(b);
         assertFalse(a.value().isPresent());
     }
@@ -195,8 +193,8 @@ public class DetectionTest {
     @Test
     public void testReadVesselIdWithRadioCallSign() {
         RadioCallSign a = (RadioCallSign) Detection
-                .readVesselId(Bits.from("010").concatWith(createVesselIdRadioCallSignForBingo())).get();
-        assertEquals("BINGO", a.value().get());
+                .readVesselId(Bits.from("010").concatWith(createVesselIdRadioCallSignForAbcSpace123())).get();
+        assertEquals("ABC 123", a.value().get());
     }
 
     @Test
@@ -563,7 +561,20 @@ public class DetectionTest {
         assertEquals(-48.79315185546875, p.lat(), 0.0000001);
         assertEquals(-69.00875854492188, p.lon(), 0.0000001);
     }
-
+    
+    @Test
+    public void testReadVesselId() {
+        Bits bits = Bits.from("11100011001110111010010001110101100101000000");
+        assertEquals("ABC 123", Detection.readVesselIdRadioCallSign(bits).value().get());
+    }
+    
+    @Test
+    public void testRotatingFieldTypeInLongMessage() {
+        Detection d = Detection.fromHexGroundSegmentRepresentation(
+                "0039823D32618658622811F725F2B1C67703FFF004030680258");
+        System.out.println(d);   
+    }
+    
     private static String leftPadWithZeros(String s, int length) {
         while (s.length() < length) {
             s = "0" + s;

--- a/src/test/resources/compliance-kit/detection-with-aircraft-registration-marking.json
+++ b/src/test/resources/compliance-kit/detection-with-aircraft-registration-marking.json
@@ -52,6 +52,6 @@
     },
     "gnssStatus" : "LOCATION_3D"
   },
-  "beacon23HexId" : "9934039823D324BE5638CEE",
-  "beacon15HexId" : "9934039823D324B"
+  "beacon23HexId" : "9934039823D392F958E33B8",
+  "beacon15HexId" : "9934039823D392F"
 }

--- a/src/test/resources/compliance-kit/tests.csv
+++ b/src/test/resources/compliance-kit/tests.csv
@@ -2,5 +2,5 @@ TYPE,TITLE,HEX,JSON
 "Detection","Specification example B-1 no Vessel Id","0039823D32618658622811F0000000000003FFF004030680258","detection-specification-example.json"
 "Detection","Example B-2 with Vessel Id of type MMSI","0039823D32618658622811F23ADE68AA17E3FFF004030680258","detection-with-mmsi-vessel-id.json"
 "Detection","Example B-2 with Vessel Id Aircraft Operator and Serial Number","0039823D32618658622811FB7AC403C00003FFF004030680258","detection-with-aircraft-operator-and-serial-number.json"
-"Detection","Example B-2 with Vessel Id Aircraft Registration Marking","0039823D32618658622811F6497CAC719DC3FFF004030680258","detection-with-aircraft-registration-marking.json"
+"Detection","Example B-2 with Vessel Id Aircraft Registration Marking","0039823D32618658622811F725F2B1C67703FFF004030680258","detection-with-aircraft-registration-marking.json"
 "Beacon23HexId","Specification example B-2","9934039823D000000000000","beacon-23-hex-id-sample.json"


### PR DESCRIPTION
2 bits were being skipped at start and they should have been skipped at the end.